### PR TITLE
Add price action signal structure

### DIFF
--- a/src/hermes_trading/__init__.py
+++ b/src/hermes_trading/__init__.py
@@ -1,3 +1,5 @@
 """Hermes Trading Bot core package."""
 
-__all__ = ["connectors"]
+from . import connectors, signals
+
+__all__ = ["connectors", "signals"]

--- a/src/hermes_trading/signals/__init__.py
+++ b/src/hermes_trading/signals/__init__.py
@@ -1,0 +1,6 @@
+"""Signal evaluation for trading strategies."""
+
+from .base import Signal
+from .price_action import PriceActionSignal
+
+__all__ = ["Signal", "PriceActionSignal"]

--- a/src/hermes_trading/signals/base.py
+++ b/src/hermes_trading/signals/base.py
@@ -1,0 +1,14 @@
+"""Interfaces for trading signals."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+
+class Signal(ABC):
+    """Abstract interface for evaluating trading signals."""
+
+    @abstractmethod
+    def evaluate(self, prices: Sequence[float]) -> bool:
+        """Return ``True`` if a signal is triggered for the given prices."""

--- a/src/hermes_trading/signals/price_action.py
+++ b/src/hermes_trading/signals/price_action.py
@@ -1,0 +1,33 @@
+"""Price action pattern based trading signals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from .base import Signal
+
+
+@dataclass
+class PriceActionSignal(Signal):
+    """Detects price action patterns within a series of prices.
+
+    Parameters
+    ----------
+    pattern:
+        Name of the pattern to evaluate. The actual pattern detection logic
+        is left as a placeholder for future implementation.
+    """
+
+    pattern: str
+
+    def evaluate(self, prices: Sequence[float]) -> bool:  # noqa: D401
+        """Evaluate whether the configured pattern exists in ``prices``.
+
+        Currently this method is a stub and always returns ``False``. Concrete
+        pattern recognition algorithms will be implemented in subsequent
+        iterations of the trading bot.
+        """
+
+        # TODO: Implement pattern recognition based on ``self.pattern``
+        return False

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,6 @@
+from hermes_trading.signals import PriceActionSignal
+
+
+def test_price_action_signal_stub_returns_false():
+    signal = PriceActionSignal(pattern="pin_bar")
+    assert signal.evaluate([1.0, 2.0, 3.0]) is False


### PR DESCRIPTION
## Summary
- define abstract `Signal` interface for evaluating trading signals
- add stub `PriceActionSignal` for future price action pattern detection
- expose new signals package and provide unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab74079df883269c6c410378be2e9c